### PR TITLE
Add option `closeOnClickBackdrop` to sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ If you are using Angular 2's default emulated view encapsulation, you may have t
 | trapFocus | boolean | `true` | Keeps focus within the sidebar when open. |
 | autoFocus | boolean | `true` | Automatically focus the first focusable element in the sidebar when opened. |
 | showBackdrop | boolean | `false` | If a translucent black backdrop overlay should appear over the page contents when the sidebar is opened.  This is ignored if the sidebar's parent container has its `allowSidebarBackdropControl` property set to `true`. |
+| closeOnClickBackdrop | boolean | `false` | Whether clicking on the backdrop of the open sidebar will close it. |
 | closeOnClickOutside | boolean | `false` | Whether clicking outside of the open sidebar will close it. |
 | keyClose | boolean | `false` | Close the sidebar when a keyboard button is pressed. |
 | keyCode | number | `27` | The [key code](http://keycode.info/) for `keyClose`. |

--- a/src/sidebar-container.component.ts
+++ b/src/sidebar-container.component.ts
@@ -27,7 +27,8 @@ import { isBrowser } from './utils';
     <div *ngIf="showBackdrop"
       aria-hidden="true"
       class="ng-sidebar__backdrop"
-      [ngClass]="backdropClass"></div>
+      [ngClass]="backdropClass"
+      (click)="_onBackdropClicked()"></div>
 
     <div class="ng-sidebar__content"
       [ngClass]="sidebarContentClass"
@@ -174,6 +175,20 @@ export class SidebarContainer implements AfterContentInit, OnChanges, OnDestroy 
     return {
       margin: `${top}px ${right}px ${bottom}px ${left}px`
     } as CSSStyleDeclaration;
+  }
+
+  /**
+   * @internal
+   *
+   * Closes sidebars when the backdrop is clicked, if they have the
+   * `closeOnClickBackdrop` option set.
+   */
+  _onBackdropClicked(): void {
+    this._sidebars.forEach((sidebar: Sidebar) => {
+      if(sidebar.opened && sidebar.showBackdrop && sidebar.closeOnClickBackdrop) {
+        sidebar.close();
+      }
+    });
   }
 
   /**

--- a/src/sidebar.component.ts
+++ b/src/sidebar.component.ts
@@ -101,6 +101,7 @@ export class Sidebar implements OnInit, OnChanges, OnDestroy {
   @Input() autoFocus: boolean = true;
 
   @Input() showBackdrop: boolean = false;
+  @Input() closeOnClickBackdrop: boolean = false;
   @Input() closeOnClickOutside: boolean = false;
 
   @Input() keyClose: boolean = false;


### PR DESCRIPTION
Sometimes you don't want the sidebar to be closed when clicking anywhere outside (the most obvious case is when you click on another menu item in the sidebar), but most users expect clicking on the backdrop to close the sidebar.